### PR TITLE
Run cmd as admin

### DIFF
--- a/app/modules/footer/index.js
+++ b/app/modules/footer/index.js
@@ -52,7 +52,12 @@ messenger.subscribe.metadata('productListChanged', handlers.productListChanged);
 messenger.subscribe.file('allFilesClosed', handlers.allFilesClosed);
 
 messenger.subscribe.metadata('productBuildFlagsChanged', (buildFlags) => {
+
   $flagsContainer.html(`<span class="flag">${buildFlags.join('</span><span class="flag">')}</span>`);
+
+  if(!$flagsContainer.is(':visible')){
+    $flagsContainer.fadeIn('fast');
+  }
 });
 
 messenger.subscribe.metadata('isInfragisticsDocumentationFile', () => {

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ A simple web content editor built with [Electron](electron.atom.io).
 For more information make sure to read the [wiki](https://github.com/craigshoemaker/livewire/wiki).
 
 		  
-## Windows Installer		
+## Installers
  
  [You can download the installers here](https://github.com/Infragistics/livewire/wiki/installers).
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ For more information make sure to read the [wiki](https://github.com/craigshoema
 
 ## Running the App from Source
 
-First, make sure you have [Node.js](https://nodejs.org/) and [Git](https://git-scm.com/downloads) installed on your machine.
+First, make sure you have [Node.js v4.5.0](https://nodejs.org/) and [Git](https://git-scm.com/downloads) installed on your machine.
 
 Then open a command prompt and install Bower (if you don't already have it installed) by executing this command:
 

--- a/readme.md
+++ b/readme.md
@@ -28,26 +28,26 @@ First, make sure you have [Node.js v4.5.0](https://nodejs.org/) and [Git](https:
 
 Then run a command prompt as administrator and install Bower (if you don't already have it installed) by executing this command:
 
-    $ npm install -g bower
+    npm install -g bower
     
 Next, in that administrative prompt, install Gulp:
 
-    $ npm install --g gulp
+    npm install --g gulp
 
 After Bower and Gulp are installed, in Windows Explorer, open the directory in which you want to download Livewire.  Right-click and choose `Git Bash Here`.  If you don't have Git Bash, open Git Shell or any Git-enabled command prompt.  Clone the repository by using this command:
 
-    $ git clone https://github.com/infragistics/livewire.git
+    git clone https://github.com/infragistics/livewire.git
 	
 This will automatically create a `livewire` subdirectory.  Change directories into `livewire`:
 
-    $ cd livewire 
+    cd livewire 
     
 Then, install the Livewire dependencies:
 
-    $ npm install
+    npm install
     
 Finally, you can start the application:
     
-    $ npm start
+    npm start
     
 Happy writing!

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ For more information make sure to read the [wiki](https://github.com/craigshoema
 		  
 ## Windows Installer		
  
- [You can download the v1.1.002 Windows 64-bit installer here](http://download.infragistics.com/users/livewire/Livewire-1.1.002-win-64.msi).
+ [You can download the installers here](https://github.com/Infragistics/livewire/wiki/installers).
 
 ## Running the App from Source
 

--- a/readme.md
+++ b/readme.md
@@ -26,19 +26,19 @@ For more information make sure to read the [wiki](https://github.com/craigshoema
 
 First, make sure you have [Node.js v4.5.0](https://nodejs.org/) and [Git](https://git-scm.com/downloads) installed on your machine.
 
-Then open a command prompt and install Bower (if you don't already have it installed) by executing this command:
+Then run a command prompt as administrator and install Bower (if you don't already have it installed) by executing this command:
 
     $ npm install -g bower
-
-After Bower is installed, switch directories to where you want to download Livewire and clone this repository by using this command:
-
-    $ git clone https://github.com/infragistics/livewire.git
     
-Next, install Gulp:
+Next, in that administrative prompt, install Gulp:
 
     $ npm install --g gulp
-    
-Next, change directories into `livewire`:
+
+After Bower and Gulp are installed, in Windows Explorer, open the directory in which you want to download Livewire.  Right-click and choose `Git Bash Here`.  Clone the repository by using this command:
+
+    $ git clone https://github.com/infragistics/livewire.git
+	
+This will automatically create a `livewire` subdirectory.  Change directories into `livewire`:
 
     $ cd livewire 
     

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Next, in that administrative prompt, install Gulp:
 
     $ npm install --g gulp
 
-After Bower and Gulp are installed, in Windows Explorer, open the directory in which you want to download Livewire.  Right-click and choose `Git Bash Here`.  Clone the repository by using this command:
+After Bower and Gulp are installed, in Windows Explorer, open the directory in which you want to download Livewire.  Right-click and choose `Git Bash Here`.  If you don't have Git Bash, open Git Shell or any Git-enabled command prompt.  Clone the repository by using this command:
 
     $ git clone https://github.com/infragistics/livewire.git
 	


### PR DESCRIPTION
Updated readme based on feedback from the Windows Forms team, as well as running the steps myself.

Basically, you need to install bower and gulp using an administrative command line.  And it's easier to run the other steps by using Git Bash.