### PR TITLE
Admin information and removed $ from commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,28 +26,28 @@ For more information make sure to read the [wiki](https://github.com/craigshoema
 
 First, make sure you have [Node.js v4.5.0](https://nodejs.org/) and [Git](https://git-scm.com/downloads) installed on your machine.
 
-Then open a command prompt and install Bower (if you don't already have it installed) by executing this command:
+Then run a command prompt as administrator and install Bower (if you don't already have it installed) by executing this command:
 
-    $ npm install -g bower
-
-After Bower is installed, switch directories to where you want to download Livewire and clone this repository by using this command:
-
-    $ git clone https://github.com/infragistics/livewire.git
+    npm install -g bower
     
-Next, install Gulp:
+Next, in that administrative prompt, install Gulp:
 
-    $ npm install --g gulp
-    
-Next, change directories into `livewire`:
+    npm install --g gulp
 
-    $ cd livewire 
+After Bower and Gulp are installed, in Windows Explorer, open the directory in which you want to download Livewire.  Right-click and choose `Git Bash Here`.  If you don't have Git Bash, open Git Shell or any Git-enabled command prompt.  Clone the repository by using this command:
+
+    git clone https://github.com/infragistics/livewire.git
+	
+This will automatically create a `livewire` subdirectory.  Change directories into `livewire`:
+
+    cd livewire 
     
 Then, install the Livewire dependencies:
 
-    $ npm install
+    npm install
     
 Finally, you can start the application:
     
-    $ npm start
+    npm start
     
 Happy writing!


### PR DESCRIPTION
* Run the command prompt as an administrator for installing bower and gulp
* Use a git-enabled command prompt for the other commands
* Don't type $ in the command prompt