### PR TITLE
Show links as tooltips in results-pane

### DIFF
--- a/app/modules/results/asciidoc.js
+++ b/app/modules/results/asciidoc.js
@@ -29,6 +29,11 @@ var handlers = {
         src = $img.attr('src');
         $img.attr('src', (basePath + '\\' + src).replace(/\//g, '\\'));
       });
+      //  Show links as tooltips
+      $('a').each(function() {
+        var $link = $(this);
+        $link.attr('title', $link.attr('href'));
+      });
 
       // make toc title H2 element
       var $tocTitle = $('#toctitle'); 

--- a/app/modules/results/asciidoc.js
+++ b/app/modules/results/asciidoc.js
@@ -31,8 +31,9 @@ var handlers = {
       });
       //  Show links as tooltips
       $('a').each(function() {
-        var $link = $(this);
-        $link.attr('title', $link.attr('href'));
+        var $link = $(this),
+          href = $link.attr('href');
+        $link.attr('title', href.replace(/<\/?sub>/g, '~'));
       });
 
       // make toc title H2 element


### PR DESCRIPTION
It's nice knowing what the link will render as without having to decipher the DocsConfig.xml and since we can't navigate to the links, I thought it would help to show them as tooltips.